### PR TITLE
Starlist keywords

### DIFF
--- a/Main/Main.sin
+++ b/Main/Main.sin
@@ -204,7 +204,7 @@ def fixed_start_time(opt, apftask):
     saved_time = ''
     if opt.fixed is not None:
         try:
-            saved_time = apftask.read('MASTER_UTSTARTLIST',timeout=5)
+            saved_time = apftask.read('MASTER_UTSTARTLIST', binary=True, timeout=5)
         except Exception as e:
             apflog("Cannot read apftask.MASTER_UTSTARTLIST: %s" % (e), level='warn', echo=True)
 
@@ -216,7 +216,7 @@ def fixed_start_time(opt, apftask):
             mn = int(mtch.group(2))
             opt.start = get_start_time(hr,mn)
             try:
-                apftask.write("MASTER_UTSTARTLIST", opt.start, wait=False)
+                apftask.write("MASTER_UTSTARTLIST", opt.start, binary=True, wait=False)
             except Exception as e:
                 apflog("Cannot write apftask.MASTER_UTSTARTLIST: %s" % (e), level='warn', echo=True)
 
@@ -649,9 +649,9 @@ def main():
         APFTask.set(parent, suffix="LAST_OBS", value=apf.ucam["OBSNUM"].read())
         ostr = "Updating last observation number to %s" % (apf.ucam["OBSNUM"].read())
         APFTask.set(parent, suffix="MESSAGE",value=ostr,wait=False)
-        apftask('MASTER_STARLIST').write('',wait=False)
-        apftask('MASTER_UTSTARTLIST').write('',wait=False)
-        apftask["MASTER_OBSBSTAR"].write(True,binary=True,wait=False)
+        apftask('MASTER_STARLIST').write('', wait=False)
+        apftask('MASTER_UTSTARTLIST').write(0, binary=True, wait=False)
+        apftask["MASTER_OBSBSTAR"].write(True, binary=True, wait=False)
 
     _ = apf.turn_off_inst()
     APFTask.set(parent, suffix="MESSAGE",value="Turning off the motors",wait=False)

--- a/Main/Observe.py
+++ b/Main/Observe.py
@@ -205,20 +205,15 @@ class Observe(threading.Thread):
             checks to see if the starlist keywords have been updated
         """
         starlist = self.apftask['MASTER_STARLIST'].read().strip()
-        utstartlist = self.apftask['MASTER_UTSTARTLIST'].read().strip()
+        utstartlist = self.apftask['MASTER_UTSTARTLIST'].read(binary=True)
 
         if starlist != "" and starlist != self.fixed_list:
             self.fixed_list = starlist
             apflog("New starlist %s detected" % (self.fixed_list), echo=True)
 
-        if utstartlist != "":
-            try:
-                utstarttime = float(utstartlist)
-            except ValueError as e:
-                apflog("ValueError: %s" % (e), echo=True, level='error')
-                utstarttime = None
-            if utstarttime is not None and utstarttime != self.start_time:
-                self.start_time = utstarttime
+        if utstartlist > 0:
+            if utstartlist != self.start_time:
+                self.start_time = utstartlist
                 apflog("New UT start time %s detected" % (str(self.start_time)), echo=True)
 
     def check_star(self, haveobserved):
@@ -749,7 +744,7 @@ class Observe(threading.Thread):
                     self.fixed_list = None
                     self.start_time = None
                     APFLib.write(self.apf.robot["MASTER_STARLIST"], "")
-                    APFLib.write(self.apf.robot["MASTER_UTSTARTLIST"], "")
+                    APFLib.write(self.apf.robot["MASTER_UTSTARTLIST"], 0, binary=True)
 
                 # this reads in the list and appends it to self.target
 
@@ -757,7 +752,7 @@ class Observe(threading.Thread):
 
                 if self.apf.ldone == tot:
                     APFLib.write(self.apf.robot["MASTER_STARLIST"], "")
-                    APFLib.write(self.apf.robot["MASTER_UTSTARTLIST"], "")
+                    APFLib.write(self.apf.robot["MASTER_UTSTARTLIST"], 0, binary=True)
                     self.fixed_list = None
                     self.start_time = None
                     self.target = None


### PR DESCRIPTION
This PR uses the starlist keywords in the apftask service as more than just a logging tool. Now those values can be written during operations and the Observe object will read new values and behave appropriately.