### PR TITLE
Read starlist keywords 

### DIFF
--- a/Main/Main.sin
+++ b/Main/Main.sin
@@ -204,9 +204,9 @@ def fixed_start_time(opt, apftask):
     saved_time = ''
     if opt.fixed is not None:
         try:
-            saved_time = apftask.read('MASTER_UTSTARTLIST', binary=True, timeout=5)
+            saved_time = apftask.read('MASTER_WHENSTARTLIST', binary=True, timeout=5)
         except Exception as e:
-            apflog("Cannot read apftask.MASTER_UTSTARTLIST: %s" % (e), level='warn', echo=True)
+            apflog("Cannot read apftask.MASTER_WHENSTARTLIST: %s" % (e), level='warn', echo=True)
 
     if opt.start is not None and opt.fixed is not None:
 
@@ -216,9 +216,9 @@ def fixed_start_time(opt, apftask):
             mn = int(mtch.group(2))
             opt.start = get_start_time(hr,mn)
             try:
-                apftask.write("MASTER_UTSTARTLIST", opt.start, binary=True, wait=False)
+                apftask.write("MASTER_WHENSTARTLIST", opt.start, binary=True, wait=False)
             except Exception as e:
-                apflog("Cannot write apftask.MASTER_UTSTARTLIST: %s" % (e), level='warn', echo=True)
+                apflog("Cannot write apftask.MASTER_WHENSTARTLIST: %s" % (e), level='warn', echo=True)
 
         else:
             logstr = "Invalid time format for fixed star list start time: %s" % (opt.start)
@@ -650,7 +650,7 @@ def main():
         ostr = "Updating last observation number to %s" % (apf.ucam["OBSNUM"].read())
         APFTask.set(parent, suffix="MESSAGE",value=ostr,wait=False)
         apftask('MASTER_STARLIST').write('', wait=False)
-        apftask('MASTER_UTSTARTLIST').write(0, binary=True, wait=False)
+        apftask('MASTER_WHENSTARTLIST').write(0, binary=True, wait=False)
         apftask["MASTER_OBSBSTAR"].write(True, binary=True, wait=False)
 
     _ = apf.turn_off_inst()

--- a/Main/Observe.py
+++ b/Main/Observe.py
@@ -205,7 +205,7 @@ class Observe(threading.Thread):
             checks to see if the starlist keywords have been updated
         """
         starlist = self.apftask['MASTER_STARLIST'].read().strip()
-        utstartlist = self.apftask['MASTER_UTSTARTLIST'].read(binary=True)
+        utstartlist = self.apftask['MASTER_WHENSTARTLIST'].read(binary=True)
 
         if starlist != "" and starlist != self.fixed_list:
             self.fixed_list = starlist
@@ -744,7 +744,7 @@ class Observe(threading.Thread):
                     self.fixed_list = None
                     self.start_time = None
                     APFLib.write(self.apf.robot["MASTER_STARLIST"], "")
-                    APFLib.write(self.apf.robot["MASTER_UTSTARTLIST"], 0, binary=True)
+                    APFLib.write(self.apf.robot["MASTER_WHENSTARTLIST"], 0, binary=True)
 
                 # this reads in the list and appends it to self.target
 
@@ -752,7 +752,7 @@ class Observe(threading.Thread):
 
                 if self.apf.ldone == tot:
                     APFLib.write(self.apf.robot["MASTER_STARLIST"], "")
-                    APFLib.write(self.apf.robot["MASTER_UTSTARTLIST"], 0, binary=True)
+                    APFLib.write(self.apf.robot["MASTER_WHENSTARTLIST"], 0, binary=True)
                     self.fixed_list = None
                     self.start_time = None
                     self.target = None


### PR DESCRIPTION
Reads the starlist keywords (instead of just writing them for logging) to allow adding  a fixed starlist without having to stop and restart the Main script.